### PR TITLE
Only set primary for gcc on x86_64.

### DIFF
--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -411,7 +411,9 @@ if(NOT DEFINED KTX_DIFF_PATH)
     message(FATAL_ERROR "KTX_DIFF_PATH not defined")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+# Even with gcc, zlib yields a slightly different compression
+# result on arm64. Yet to be investigated.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CPU_ARCHITECTURE STREQUAL x86_64)
     set(CLITEST_ARGS "--primary")
 else()
     set(CLITEST_ARGS "")

--- a/clitests/clitest.py
+++ b/clitests/clitest.py
@@ -386,7 +386,8 @@ if __name__ == '__main__':
             messages.extend(["      " + msg for msg in subcase_messages])
             messages.append(f"      Run subcase with:")
             ktxdiff_arg = f" -d \"{cli_args.ktxdiff_path}\"" if cli_args.ktxdiff_path else ""
-            messages.append(f"        clitest.py -e \"{cli_args.executable_path}\"{ktxdiff_arg} {cli_args.json_test_file} {ctx.cmdArgs()}")
+            primary_arg = f" --primary" if cli_args.primary else ""
+            messages.append(f"        clitest.py{primary_arg} -e \"{cli_args.executable_path}\"{ktxdiff_arg} {cli_args.json_test_file} {ctx.cmdArgs()}")
             subcases_failed += 1
             failed = True
 

--- a/clitests/tests/create/raw_zlib.json
+++ b/clitests/tests/create/raw_zlib.json
@@ -2,7 +2,7 @@
     "description": "Test creation of ZLIB compressed textures.",
     "command": "ktx create --testrun ${level[flag]} --raw --format ${subcase} --width 8 --height 8 --levels 1 input/raw/raw_${subcase}_2D_8x8.raw output/create/raw_zlib/output_${subcase}_2D_ZLIB${level[name]}.ktx2",
     "status": 0,
-    "comment": "On MacOS zlib yields a slightly different compression result, but color values should not differ",
+    "comment": "On arm64 zlib yields a slightly different compression result, but color values should not differ",
     "outputTolerance": 0.001,
     "outputs": {
         "output/create/raw_zlib/output_${subcase}_2D_ZLIB${level[name]}.ktx2": "golden/create/raw_zlib/output_${subcase}_2D_ZLIB${level[name]}.ktx2"

--- a/clitests/tests/create/sample_zlib.json
+++ b/clitests/tests/create/sample_zlib.json
@@ -2,7 +2,7 @@
     "description": "Test creation of ZLIB compressed textures with the sample PNG input files.",
     "command": "ktx create --testrun ${level[flag]} --format ${subcase[format]} input/png_sample/${subcase[file]}${subcase[ext]} output/create/sample_zlib/${subcase[file]}_ZLIB${level[name]}.ktx2",
     "status": 0,
-    "comment": "On MacOS zlib yields a slightly different compression result, but color values should not differ",
+    "comment": "On arm64 zlib yields a slightly different compression result, but color values should not differ",
     "outputTolerance": 0.001,
     "outputs": {
         "output/create/sample_zlib/${subcase[file]}_ZLIB${level[name]}.ktx2": "golden/create/sample_zlib/${subcase[file]}_ZLIB${level[name]}.ktx2"


### PR DESCRIPTION
Due to slightly different compression results from zlib on arm64 which mean ktxdiff must be used.

Add value of cli_args.primary to command echoed for re-running a failed subcase so avoid someone going into a black hole for 2 hours discovering why the test passes with the echoed command but not when run via ctests.