### PR TITLE
Update tests and golden files for --normalize error handling fixes.

### DIFF
--- a/clitests/golden/create/cli_errors/normalize_with_assign_tf_nonlinear.err.txt
+++ b/clitests/golden/create/cli_errors/normalize_with_assign_tf_nonlinear.err.txt
@@ -1,0 +1,1 @@
+ktx create fatal: --assign-tf value is KHR_DF_TRANSFER_NTSC. Normalize can only be used if the transfer function is linear or none. See 'ktx create --help'.

--- a/clitests/golden/create/cli_errors/normalize_with_convert_tf_srgb.err.txt
+++ b/clitests/golden/create/cli_errors/normalize_with_convert_tf_srgb.err.txt
@@ -1,0 +1,1 @@
+ktx create fatal: --convert-tf value is KHR_DF_TRANSFER_SRGB. Normalize can only be used if the transfer function is linear or none. See 'ktx create --help'.

--- a/clitests/golden/create/cli_errors/normalize_with_srgb.err.txt
+++ b/clitests/golden/create/cli_errors/normalize_with_srgb.err.txt
@@ -1,1 +1,1 @@
-ktx create warning: Input file "input/png/colorspace_sRGB.png" is undergoing a visual lossy color conversion from KHR_DF_TRANSFER_SRGB to KHR_DF_TRANSFER_LINEAR. Specify an _SRGB format with --format to prevent this warning.
+ktx create fatal: Option --normalize cannot be used with sRGB formats. See 'ktx create --help'.

--- a/clitests/tests/create/cli_errors.json
+++ b/clitests/tests/create/cli_errors.json
@@ -43,8 +43,9 @@
             { "rc": 5, "id": "generate_mipmap_uint_from_float", "flags": "--generate-mipmap --format R16_UINT input/exr/basic_R_FLOAT_HDR_16x16.exr output.ktx2" },
             { "rc": 5, "id": "generate_mipmap_uint_from_uint", "flags": "--generate-mipmap --format R32_UINT input/exr/basic_R_UINT_16x16.exr output.ktx2" },
             { "rc": 1, "id": "generate_mipmap_3d", "flags": "--generate-mipmap --depth 2 --format R8_UNORM input/png/basic_RGB8_16x16.png input/png/basic_RGB8_16x16.png output.ktx2" },
-            { "rc": 0, "id": "normalize_with_srgb", "flags": "--normalize --format R8_UNORM input/png/colorspace_sRGB.png output.ktx2" },
-            { "rc": 0, "id": "normalize_with_tf", "flags": "--normalize --assign-tf=linear --format R8_UNORM input/png/colorspace_sRGB.png output.ktx2" },
+            { "rc": 1, "id": "normalize_with_srgb", "flags": "--normalize --format R8_SRGB input/png/colorspace_sRGB.png output.ktx2" },
+            { "rc": 1, "id": "normalize_with_assign_tf_nonlinear", "flags": "--normalize --format R8_UNORM --assign-tf ntsc input/png/colorspace_sRGB.png output.ktx2" },
+            { "rc": 1, "id": "normalize_with_convert_tf_srgb", "flags": "--normalize --format R16_SFLOAT --convert-tf srgb input/exr/basic_RGBA_HALF_HDR_16x16.exr output.ktx2" },
             { "rc": 1, "id": "normalize_with_raw", "flags": "--raw --normalize --format R8_UNORM input/png/basic_RGB8_16x16.png output.ktx2" },
 
             { "rc": 1, "id": "raw_too_many_in_2d", "flags": "--raw --width 8 --height 8 --format R8_UNORM input/raw/raw_R8_UNORM_2D_8x8.raw input/raw/raw_R8_UNORM_2D_8x8.raw output.ktx2" },


### PR DESCRIPTION
2 or the 3 previous tests were not actually errors and there was no test of error handling when specifying an SRGB format with with `--format`.