### PR TITLE
Add configuration option to set primary platform

### DIFF
--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -455,22 +455,42 @@ if(NOT DEFINED KTX_DIFF_PATH)
     message(FATAL_ERROR "KTX_DIFF_PATH not defined")
 endif()
 
-# Even with gcc, zlib yields a slightly different compression
-# result on arm64 cf x86_64. Yet to be investigated.
+# Detect if this is running on the designated primary platform, that is the
+# platform where golden .ktx2 files should be regenerated and where exact
+# matches are expected when running the tests.
+#
+# It has been tested that gcc on Ubuntu 24.04, gcc on macOS Sequoia and
+# AppleClang on macOS Sequoia all produce the same results. However,
+# even with gcc, zlib yields a slightly different compression
+# result on arm64 c/f x86_64. Yet to be investigated. We think that,
+# with this exception, the encoding results would be the same.
+#
+# Why is arm64 the primary platform? Because that is what the project's
+# lead developer has. Regenerating on x64_64 would be difficult.
 cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
-if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") AND CPU_ARCHITECTURE STREQUAL "arm64")
-    set(primary_platform_default ON)
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    AND CPU_ARCHITECTURE STREQUAL "arm64")
+    set(primary_platform ON)
 else()
-    set(primary_platform_default OFF)
+    set(primary_platform OFF)
 endif()
-# Detection of GCC via CMake is unreliable. For example when using the "default
-# compilers" on Ubuntu the compiler reports itself as cc. Provide an override
-option(KTX_TOOLS_CTS_PRIMARY_PLATFORM "Do not change this unless you *really* know what you are doing." ${primary_platform_default})
+# Provide an option to override the primary platform choice. To be used
+# with great care only for:
+# - testing if a platform considered non-primary is getting the same results
+#   as primary
+# - to test ktxdiff on a primary platform
+# - overriding the choice when you absolutely know the platform is primary
+#   but the detection is failing for some reason.
+# It also provides useful feedback of the value.
+option(KTX_TOOLS_CTS_PRIMARY_PLATFORM
+    "Do not change this unless you *really* know what you are doing."
+    ${primary_platform}
+)
 mark_as_advanced(KTX_TOOLS_CTS_PRIMARY_PLATFORM)
 if(KTX_TOOLS_CTS_PRIMARY_PLATFORM)
     set(CLITEST_ARGS "--primary")
 endif()
-unset(primary_platform_default)
+unset(primary_platform)
 
 # If this is a function, for reasons I have yet to understand,
 # add_custom_command() does nothing. All variables have the expected

--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -455,34 +455,51 @@ if(NOT DEFINED KTX_DIFF_PATH)
     message(FATAL_ERROR "KTX_DIFF_PATH not defined")
 endif()
 
-# Detect if this is running on the designated primary platform, that is the
-# platform where golden .ktx2 files should be regenerated and where exact
-# matches are expected when running the tests.
+# Detect if this is running on the designated primary platform.
 #
-# It has been tested that gcc on Ubuntu 24.04, gcc on macOS Sequoia and
-# AppleClang on macOS Sequoia all produce the same results.
+# A primary platform is designated in order to prevent "drifting" of image
+# data in the golden reference files. It should always be used for
+# regenerating golden .ktx2 files for tests with outputTolerance. When
+# running the tests on this platform, any outputTolerance is ignored; exact
+# matches are expected.
 #
-# It was intended that this should be dependent only on the compiler. However,
-# even with gcc, zlib yields a slightly different compression
-# result on arm64 c/f x86_64. Yet to be investigated. Therefore primary is
-# limited to arm64. Why arm64? Because that is what the project's lead
-# developer has. Regenerating on x64_64 would be difficult. We think that,
-# with the exception of zlib, the encoding results would be the same.
-cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
+# The chosen primary platform is gcc. However, even with gcc, it has been
+# observed that zlib yields a slightly different compression result on
+# arm64 c/f x86_64, a problem yet to be investigated. Therefore the
+# platform must be gcc on arm64. Why arm64? Because that is what the
+# project's lead developer has. Regenerating on x64_64 would be difficult.
+# With the exception of this zlib issue, the encoding results with gcc are
+# expected to be the same across CPU architectures.
+#
+# By setting the float-point compiler options to request identical FP
+# handling across compilers, KTX-Software endeavours to make the results
+# deterministic. Testing has shown that gcc on Ubuntu 24.04, gcc on macOS
+# Sequoia and AppleClang on macOS Sequoia produce identical results.
+# Therefore AppleClang is also allowed as primary.
+#
+# For both ClangCL and MSVC on Windows, only a single subcase's result
+# differs from that of the primary platform. That subcase can be run with
+# the following:
+#   tests/create/encode_uastc_hdr6x6i_params.json --select "{'id': 'level_12', 'tolerance': '1.00', 'args': '--uastc-hdr-6x6i-level 12'}" --subcase "R16G16B16_SFLOAT"
+# This is yet to be investigated.
+#
+#cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
 if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     AND CPU_ARCHITECTURE STREQUAL "arm64")
     set(primary_platform ON)
 else()
     set(primary_platform OFF)
 endif()
-# Provide an option to override the automatic primary platform choice. To
-# be used with great care only for:
+
+# Provide an option to override the automatic primary platform choice.
+#
+# To be used with great care only for:
 # - testing if a platform considered non-primary is getting the same results
 #   as primary
 # - to test ktxdiff on a primary platform
 # - overriding the choice when you absolutely know the platform is primary
 #   but the detection is failing for some reason.
-# It also provides useful feedback of the value.
+# In the CMake GUI, it also provides useful feedback of the current value.
 option(KTX_TOOLS_CTS_PRIMARY_PLATFORM
     "Do not change this unless you *really* know what you are doing."
     ${primary_platform}

--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -460,13 +460,14 @@ endif()
 # matches are expected when running the tests.
 #
 # It has been tested that gcc on Ubuntu 24.04, gcc on macOS Sequoia and
-# AppleClang on macOS Sequoia all produce the same results. However,
-# even with gcc, zlib yields a slightly different compression
-# result on arm64 c/f x86_64. Yet to be investigated. We think that,
-# with this exception, the encoding results would be the same.
+# AppleClang on macOS Sequoia all produce the same results.
 #
-# Why is arm64 the primary platform? Because that is what the project's
-# lead developer has. Regenerating on x64_64 would be difficult.
+# It was intended that this should be dependent only on the compiler. However,
+# even with gcc, zlib yields a slightly different compression
+# result on arm64 c/f x86_64. Yet to be investigated. Therefore primary is
+# limited to arm64. Why arm64? Because that is what the project's lead
+# developer has. Regenerating on x64_64 would be difficult. We think that,
+# with the exception of zlib, the encoding results would be the same.
 cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
 if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     AND CPU_ARCHITECTURE STREQUAL "arm64")
@@ -474,8 +475,8 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Appl
 else()
     set(primary_platform OFF)
 endif()
-# Provide an option to override the primary platform choice. To be used
-# with great care only for:
+# Provide an option to override the automatic primary platform choice. To
+# be used with great care only for:
 # - testing if a platform considered non-primary is getting the same results
 #   as primary
 # - to test ktxdiff on a primary platform

--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -496,7 +496,7 @@ endif()
 # To be used with great care only for:
 # - testing if a platform considered non-primary is getting the same results
 #   as primary
-# - to test ktxdiff on a primary platform
+# - testing ktxdiff on a primary platform
 # - overriding the choice when you absolutely know the platform is primary
 #   but the detection is failing for some reason.
 # In the CMake GUI, it also provides useful feedback of the current value.

--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -458,19 +458,19 @@ endif()
 # Even with gcc, zlib yields a slightly different compression
 # result on arm64 cf x86_64. Yet to be investigated.
 cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CPU_ARCHITECTURE STREQUAL arm64)
-    set(CLITEST_ARGS "--primary")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") AND CPU_ARCHITECTURE STREQUAL "arm64")
+    set(primary_platform_default ON)
 else()
-    set(CLITEST_ARGS "")
+    set(primary_platform_default OFF)
 endif()
-
 # Detection of GCC via CMake is unreliable. For example when using the "default
 # compilers" on Ubuntu the compiler reports itself as cc. Provide an override
-option(CTS_PRIMARY "Treat as primary platform when regenerating tests." OFF)
-mark_as_advanced(CTS_PRIMARY)
-if(CTS_PRIMARY)
+option(KTX_TOOLS_CTS_PRIMARY_PLATFORM "Do not change this unless you *really* know what you are doing." ${primary_platform_default})
+mark_as_advanced(KTX_TOOLS_CTS_PRIMARY_PLATFORM)
+if(KTX_TOOLS_CTS_PRIMARY_PLATFORM)
     set(CLITEST_ARGS "--primary")
 endif()
+unset(primary_platform_default)
 
 # If this is a function, for reasons I have yet to understand,
 # add_custom_command() does nothing. All variables have the expected

--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -456,11 +456,20 @@ if(NOT DEFINED KTX_DIFF_PATH)
 endif()
 
 # Even with gcc, zlib yields a slightly different compression
-# result on arm64. Yet to be investigated.
+# result on arm64 cf x86_64. Yet to be investigated.
+cmake_print_variables(CMAKE_CXX_COMPILER_ID CMAKE_CXX_COMPILER_FRONTEND_VARIANT CPU_ARCHITECTURE)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CPU_ARCHITECTURE STREQUAL arm64)
     set(CLITEST_ARGS "--primary")
 else()
     set(CLITEST_ARGS "")
+endif()
+
+# Detection of GCC via CMake is unreliable. For example when using the "default
+# compilers" on Ubuntu the compiler reports itself as cc. Provide an override
+option(CTS_PRIMARY "Treat as primary platform when regenerating tests." OFF)
+mark_as_advanced(CTS_PRIMARY)
+if(CTS_PRIMARY)
+    set(CLITEST_ARGS "--primary")
 endif()
 
 # If this is a function, for reasons I have yet to understand,


### PR DESCRIPTION
Add a CMake option to set the primary platform. The help legend for which says "Do not change this unless you *really* know what you are doing." The uses for this option are:

- testing if a platform considered non-primary is getting the same results as primary
- testing ktxdiff on a primary platform
- overriding the choice when you absolutely know the platform is primary but the detection is failing for some reason.

In the CMake GUI, it also provides useful feedback of the current value.

Fixes #27. Note that detection is working better than when the issue was created. Whether this is down to changes in CMake or changes in the compilers/platforms is unknown.