### PR TITLE
Remove tolerances for HDR tests except 6x6i level 12

### DIFF
--- a/clitests/tests/create/encode_uastc_hdr4x4_params.json
+++ b/clitests/tests/create/encode_uastc_hdr4x4_params.json
@@ -2,7 +2,7 @@
     "description": "Test create with UASTC HDR 4x4 encoding with various parameter combinations.",
     "command": "ktx create --testrun --raw --format ${subcase} --width 8 --height 8 --threads 1 --encode uastc-hdr-4x4 ${select[args]} input/raw/raw_${subcase}_2D_8x8.raw output/create/encode_uastc_hdr4x4_params/output_${subcase}_${select[id]}.ktx2",
     "status": 0,
-    "outputTolerance": 0.08,
+    "outputTolerance": 0.00,
     "outputs": {
         "output/create/encode_uastc_hdr4x4_params/output_${subcase}_${select[id]}.ktx2": "golden/create/encode_uastc_hdr4x4_params/output_${subcase}_${select[id]}.ktx2"
     },

--- a/clitests/tests/create/encode_uastc_hdr6x6i_params.json
+++ b/clitests/tests/create/encode_uastc_hdr6x6i_params.json
@@ -6,15 +6,16 @@
     "outputs": {
         "output/create/encode_uastc_hdr6x6i_params/output_${subcase}_${select[id]}.ktx2": "golden/create/encode_uastc_hdr6x6i_params/output_${subcase}_${select[id]}.ktx2"
     },
+    "comment": "level12 differs on Windows c/f Linux & macOS for all compmilers except gcc. The difference is VERY large.",
     "args": {
         "select": [
-            { "id": "lambda", "tolerance": "0.08", "args": "--uastc-hdr-lambda 1000" },
-            { "id": "level_0", "tolerance": "0.08", "args": "--uastc-hdr-6x6i-level 0" },
-            { "id": "level_2", "tolerance": "0.08", "args": "--uastc-hdr-6x6i-level 2" },
-            { "id": "level_4", "tolerance": "0.08", "args": "--uastc-hdr-6x6i-level 4" },
-            { "id": "level_12", "tolerance": "1.00", "args": "--uastc-hdr-6x6i-level 12" },
-            { "id": "combination_1", "tolerance": "0.08", "args": "--uastc-hdr-6x6i-level 0 --uastc-hdr-lambda 2000" },
-            { "id": "combination_2", "tolerance": "0.08", "args": "--uastc-hdr-6x6i-level 3 --uastc-hdr-lambda 5000" }
+            { "id": "lambda", "tolerance": "0.00", "args": "--uastc-hdr-lambda 1000" },
+            { "id": "level_0", "tolerance": "0.00", "args": "--uastc-hdr-6x6i-level 0" },
+            { "id": "level_2", "tolerance": "0.00", "args": "--uastc-hdr-6x6i-level 2" },
+            { "id": "level_4", "tolerance": "0.00", "args": "--uastc-hdr-6x6i-level 4" },
+            { "id": "level_12", "tolerance": "0.57", "args": "--uastc-hdr-6x6i-level 12" },
+            { "id": "combination_1", "tolerance": "0.00", "args": "--uastc-hdr-6x6i-level 0 --uastc-hdr-lambda 2000" },
+            { "id": "combination_2", "tolerance": "0.00", "args": "--uastc-hdr-6x6i-level 3 --uastc-hdr-lambda 5000" }
         ],
         "subcase": [
             "R16G16B16_SFLOAT",


### PR DESCRIPTION
whose value is updated for float-aware ktxdiff.