### PR TITLE
Add ASAN_OPTIONS ENV variable to each test case

### DIFF
--- a/clitests/CMakeLists.txt
+++ b/clitests/CMakeLists.txt
@@ -534,6 +534,10 @@ endmacro()
 
 foreach(CASE_FILE ${CASELIST})
     add_test_case(${CASE_FILE} tests ktxToolsTest ${KTX_TOOLS_PATH})
+    set_tests_properties(${FULL_CASE_NAME} PROPERTIES
+      ENVIRONMENT
+          "ASAN_OPTIONS=allocator_may_return_null=1"
+    )
 endforeach()
 
 add_custom_target(clitests_regen_golden


### PR DESCRIPTION
CTS small update related to: https://github.com/KhronosGroup/KTX-Software/pull/1205

This adds ASAN_OPTIONS ENV environment to each test case and sets it to: "allocator_may_return_null=1"
This is done to suppress AddressSanitizer from returning an error when we expect KTX_OUT_OF_MEMORY (e.g., when malloc'ing very large blocks).